### PR TITLE
Expose the uid to the new account email

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -51,6 +51,7 @@ func NewAccountEmail(uid string) {
 	}
 
 	vars := map[string]interface{}{
+    "uid": uid,
 		"link": fmt.Sprintf("%s/auth/setup/%s", viper.GetString("email_link_base"), model.SignToken(app.AccountSetupSalt, token.Token))}
 
 	err = ctx.SendEmail(token.Email, fmt.Sprintf("[%s] New Account Setup", viper.GetString("email_prefix")), "setup-account.txt", vars)

--- a/templates/email/setup-account.txt
+++ b/templates/email/setup-account.txt
@@ -1,4 +1,4 @@
-Use the following link to setup your account. 
+Your account "{{ .uid }}" has been createad, please use the following link to finalize the setup:
 
     {{ .link }}
 


### PR DESCRIPTION
This commit exposes the `uid` to the email sent on account creation.

This allows a more user-friendly email for the user, since the account name is now explicit in the email. It is also useful in context where the user name is generated and unknown from the user until first connection.