### PR TITLE
Support TLS SMTP

### DIFF
--- a/mokey.yaml.sample
+++ b/mokey.yaml.sample
@@ -105,10 +105,14 @@ smtp_host: "localhost"
 #smtp_password: "password"
 
 #------------------------------------------------------------------------------
-# SMTP port / StartTLS
+# SMTP port / TLS
+# Possible values for TLS are:
+#   - on: Connection is fully encrypted with TLS
+#   - off: Connection is unencrypted
+#   - starttls: Connections is encrypted on demand via the STARTTLS command
 #------------------------------------------------------------------------------
 smtp_port: 25
-smtp_starttls: false
+smtp_tls: "off"
 
 #------------------------------------------------------------------------------
 # From address used when sending emails

--- a/util/pgp.go
+++ b/util/pgp.go
@@ -278,10 +278,19 @@ func (e *Emailer) sendEmail(email, subject, tmpl string, data map[string]interfa
 	
 	if (viper.IsSet("smtp_username") && viper.IsSet("smtp_password")) {
 		auth := smtp.PlainAuth("", viper.GetString("smtp_username"), viper.GetString("smtp_password"), viper.GetString("smtp_host"))
-		c.Auth(auth)
+		if err = c.Auth(auth); err != nil {
+			log.Error(err)
+			return err
+		}
 	}
-	c.Mail(viper.GetString("email_from"))
-	c.Rcpt(email)
+	if err = c.Mail(viper.GetString("email_from")); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = c.Rcpt(email); err != nil {
+		log.Error(err)
+		return err
+	}
 
 	wc, err := c.Data()
 	if err != nil {

--- a/util/pgp.go
+++ b/util/pgp.go
@@ -275,8 +275,8 @@ func (e *Emailer) sendEmail(email, subject, tmpl string, data map[string]interfa
 			return err
 		}
 	}
-	
-	if (viper.IsSet("smtp_username") && viper.IsSet("smtp_password")) {
+
+	if viper.IsSet("smtp_username") && viper.IsSet("smtp_password") {
 		auth := smtp.PlainAuth("", viper.GetString("smtp_username"), viper.GetString("smtp_password"), viper.GetString("smtp_host"))
 		if err = c.Auth(auth); err != nil {
 			log.Error(err)


### PR DESCRIPTION
In 449d946e983bb3dd8231185d2f499d7df9ede0fa support for SMTP STARTTLS was added. Support for TLS SMTP (all encrypted) is the only one missing 😄

I'll brush up my (lacking) Go skills and prepare a small PR since I made it work already for our installation. I propose we deprecate the `smtp_starttls` boolean option and use `smtp_tls` with three values, `off`, `on`, `starttls`. Would that be acceptable?