### PR TITLE
Added character constraint notes to *_key: lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,8 @@ keytab, auth and encryption keys::
     $ vim /etc/mokey/mokey.yaml
     dsn: "user:pass@/dbname?parseTime=true"
     keytab: "/etc/mokey/keytab/mokeyapp.keytab"
-    auth_key: "32 or 64 bytes random key"
-    enc_key: "16, 24, or 32 byte random key"
+    auth_key: "32 or 64 bytes random key" # Must only contain numbers, upper case, and lower case
+    enc_key: "16, 24, or 32 byte random key" # Must only contain numbers, upper case, and lower case
     [ edit to taste ]
 
 It's highly recommended to run mokey using HTTPS. You'll need an SSL


### PR DESCRIPTION
In playing around with this, I could not get special characters to work, whether I used URL encoding or not.  (Perhaps I wasn't doing it right?)  Only numbers, upper case, and lower case characters would allow mokey to start.