### PR TITLE
Fix "email sent successfully" log placement

### DIFF
--- a/server/signup.go
+++ b/server/signup.go
@@ -240,13 +240,12 @@ func (h *Handler) createAccount(uid, email, email2, first, last, pass, pass2, ca
 			}).Error("Failed to send new account email")
 
 			// TODO: should we tell user about this?
+		} else {
+			log.WithFields(log.Fields{
+				"uid":   uid,
+				"email": email,
+			}).Warn("New user account email sent successfully")
 		}
 	}
-
-	log.WithFields(log.Fields{
-		"uid":   uid,
-		"email": email,
-	}).Warn("New user account email sent successfully")
-
 	return nil
 }


### PR DESCRIPTION
Before this patch, if require_verify_email was false, mokey log would show "New user account email sent successfully" even if no email was sent.