### PR TITLE
Add option to require admin verification to enable new account

### DIFF
--- a/mokey.yaml.sample
+++ b/mokey.yaml.sample
@@ -180,8 +180,16 @@ pgp_sign: false
 # default_homedir: "/home"
 #
 #------------------------------------------------------------------------------
+# Disable new user accounts. With this option enabled new
+# accounts are disabled by default until a FreeIPA admin activates them.
+# This option is mutually exclusive with require_verify_email.
+#------------------------------------------------------------------------------
+# disable_new_user: false
+
+#------------------------------------------------------------------------------
 # Require users to verify email address. With this option enabled new accounts
 # are disabled by default until the user verifies their email address
+# This option is mutually exclusive with disable_new_user.
 #------------------------------------------------------------------------------
 # require_verify_email: false
 

--- a/mokey.yaml.sample
+++ b/mokey.yaml.sample
@@ -179,17 +179,18 @@ pgp_sign: false
 # default_shell: "/bin/bash"
 # default_homedir: "/home"
 #
+
 #------------------------------------------------------------------------------
-# Disable new user accounts. With this option enabled new
+# Require FreeIPA admin to activate the account. With this option enabled new
 # accounts are disabled by default until a FreeIPA admin activates them.
 # This option is mutually exclusive with require_verify_email.
 #------------------------------------------------------------------------------
-# disable_new_user: false
+# require_verify_admin: false
 
 #------------------------------------------------------------------------------
 # Require users to verify email address. With this option enabled new accounts
 # are disabled by default until the user verifies their email address
-# This option is mutually exclusive with disable_new_user.
+# This option is mutually exclusive with require_verify_admin.
 #------------------------------------------------------------------------------
 # require_verify_email: false
 

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ func init() {
 	viper.SetDefault("min_passwd_classes", 2)
 	viper.SetDefault("develop", false)
 	viper.SetDefault("require_verify_email", false)
+	viper.SetDefault("require_verify_admin", false)
 	viper.SetDefault("enable_api_keys", false)
 	viper.SetDefault("setup_max_age", 86400)
 	viper.SetDefault("reset_max_age", 3600)

--- a/server/signup.go
+++ b/server/signup.go
@@ -20,7 +20,6 @@ import (
 func init() {
 	viper.SetDefault("enable_user_signup", true)
 	viper.SetDefault("enable_captcha", true)
-	viper.SetDefault("disable_new_user", false)
 	viper.SetDefault("default_shell", "/bin/bash")
 	viper.SetDefault("default_homedir", "/home")
 }
@@ -30,7 +29,7 @@ func (h *Handler) CreateAccount(c echo.Context) error {
 	vars := map[string]interface{}{
 		"csrf":                 c.Get("csrf").(string),
 		"require_verify_email": viper.GetBool("require_verify_email"),
-		"disable_new_user":     viper.GetBool("disable_new_user"),
+		"require_verify_admin": viper.GetBool("require_verify_admin"),
 	}
 
 	uid := c.FormValue("uid")
@@ -220,7 +219,7 @@ func (h *Handler) createAccount(uid, email, email2, first, last, pass, pass2, ca
 		"uid": uid,
 	}).Warn("User password set successfully")
 
-	if viper.GetBool("disable_new_user") {
+	if viper.GetBool("require_verify_admin") {
 		err = h.client.UserDisable(uid)
 		if err != nil {
 			log.WithFields(log.Fields{

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -10,7 +10,11 @@
 {{ with .success }}
     <br/>
     <br/>
-    <div style="margin-top: 25px" class="alert alert-success">Your account as been created. {{ if $.require_verify_email }}You must verify your email address to activate your account. Check your email for further instructions.{{ end }}</div>
+    <div style="margin-top: 25px" class="alert alert-success">
+        Your account as been created.
+        {{ if $.require_verify_email }}You must verify your email address to activate your account. Check your email for further instructions.{{ end }}
+        {{ if $.disable_new_user }}An administrator will need to activate your account before you can use it.{{ end }}
+    </div>
 {{ else }}
 
 <form class="form-horizontal form-signup" role="form" method="POST">

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -13,7 +13,7 @@
     <div style="margin-top: 25px" class="alert alert-success">
         Your account as been created.
         {{ if $.require_verify_email }}You must verify your email address to activate your account. Check your email for further instructions.{{ end }}
-        {{ if $.disable_new_user }}An administrator will need to activate your account before you can use it.{{ end }}
+        {{ if $.require_verify_admin }}An administrator will need to activate your account before you can use it.{{ end }}
     </div>
 {{ else }}
 


### PR DESCRIPTION
**What?**
This gives the ability to FreeIPA admins to manually activate accounts after they have been created. This option is mutually exclusive with `require_verify_email`.

**Why?**
I have developed for Compute Canada the project [Magic Castle](https://github.com/computecanada/magic_castle) that deploys Slurm clusters in the cloud for training and development purposes. It uses FreeIPA for DNS and user management.

For workshops using a Magic Castle cluster, we currently generates a number of guest accounts with common password and distribute those to participants. 

Mokey (which is great, thank you for building it!) enables us to have attendees register themselves, but we would like to be able to validate manually the account request before allowing the user access to the cluster. The account activation will be done through the FreeIPA admin portal.

**Why Draft?**
I am marking this as a draft request as I am open to discussion on the implementation, name and documentation of the proposed feature. This is meant as a functional starting point that currently satisfies the need exposed in the background.