### PR TITLE
Verify nsaccountlock before sending password reset email

### DIFF
--- a/server/account.go
+++ b/server/account.go
@@ -238,6 +238,13 @@ func (h *Handler) sendPasswordReset(uid, captchaID, captchaSol string) error {
 		return errors.New("Invalid username")
 	}
 
+	if userRec.NSAccountLock {
+		log.WithFields(log.Fields{
+			"uid": uid,
+		}).Error("Forgotpw: user account is disabled")
+		return errors.New("Your account is disabled")
+	}
+
 	if len(userRec.Email) == 0 {
 		log.WithFields(log.Fields{
 			"uid": uid,


### PR DESCRIPTION
If the user account is disabled, changing the password is not possible and if the user tries to reset its password he will get a fatal error message and Mokey logs the following message:
```
timestamp level=error msg="failed to set user password in FreeIPA" error="ipa: change password failed. Unknown status" uid=username
```

This patches verify nsaccountlock before sending the email, and notify the user his account is disabled is nsaccountlock is true while not sending any email.