### PR TITLE
Added option to always skip consent in hydra login flow

### DIFF
--- a/mokey.yaml.sample
+++ b/mokey.yaml.sample
@@ -214,6 +214,7 @@ develop: false
 # Hydra config
 #------------------------------------------------------------------------------
 # hydra_admin_url: "https://localhost:4445"
+# hydra_consent_skip: false
 # hydra_consent_timeout: 86400
 # hydra_login_timeout: 86400
 # hydra_fake_tls_termination: true

--- a/server/hydra.go
+++ b/server/hydra.go
@@ -60,7 +60,7 @@ func (h *Handler) ConsentGet(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to validate consent")
 	}
 
-	if consent.Skip {
+	if viper.GetBool("hydra_consent_skip") || consent.Skip {
 		log.WithFields(log.Fields{
 			"user": consent.Subject,
 		}).Info("Hydra requested we skip consent")

--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,7 @@ func init() {
 	viper.SetDefault("redis", ":6379")
 	viper.SetDefault("max_requests", 15)
 	viper.SetDefault("rate_limit_expire", 3600)
+	viper.SetDefault("hydra_consent_skip", false)
 	viper.SetDefault("hydra_login_timeout", 86400)
 	viper.SetDefault("hydra_consent_timeout", 86400)
 }


### PR DESCRIPTION
Added hydra_consent_skip parameter. If missing it will be set to false by default.

This addresses: https://github.com/ubccr/mokey/issues/71