### PR TITLE
Restrict username to lowercase and not only number when signing up

### DIFF
--- a/server/signup.go
+++ b/server/signup.go
@@ -140,6 +140,10 @@ func (h *Handler) createAccount(uid, email, email2, first, last, pass, pass2, ca
 		return errors.New("Username must be alpha numeric")
 	}
 
+	if !valid.IsLowerCase(uid) {
+		return errors.New("Username must be lowercase")
+	}
+
 	if len(first) == 0 || len(first) > 150 {
 		return errors.New("Please provide your first name")
 	}

--- a/server/signup.go
+++ b/server/signup.go
@@ -136,6 +136,10 @@ func (h *Handler) createAccount(uid, email, email2, first, last, pass, pass2, ca
 		return errors.New("Please provide a username")
 	}
 
+	if valid.IsNumeric(uid) {
+		return errors.New("Username must include at least one letter")
+	}
+
 	if !valid.IsAlphanumeric(uid) {
 		return errors.New("Username must be alpha numeric")
 	}


### PR DESCRIPTION
Mokey currently allows case-sensitive username when signing-up. However, the `user_add` rpc call sanitizes the username and make it all lowercase. The user signing-up is never warned, so it might try to login with the case sensitive version of its username.

Furthermore, the homedir value is created in Mokey and is not sanitized by the rpc_call. So when the user logins with its lowercase username, the value of $HOME is wrong, and the user's session starts in /.

This PR proposes to make sure the username is lowercase. I have also added check that the username is not only made of numbers, which is not allowed in FreeIPA.