### PR TITLE
Example for adding "ipauserauthtype" to the "Modify Users" permission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ to be installed)::
     $ ipa role-add-privilege 'Mokey User Manager' --privilege='User Administrators'
     $ ipa user-add mokeyapp --first Mokey --last App
     $ ipa role-add-member 'Mokey User Manager' --users=mokeyapp
+    $ ipa permission-mod 'System: Modify Users' --includedattrs=ipauserauthtype
     $ ipa-getkeytab -s [your.ipa-master.server] -p mokeyapp -k /etc/mokey/keytab/mokeyapp.keytab
     $ chmod 640 /etc/mokey/keytab/mokeyapp.keytab
     $ chgrp mokey /etc/mokey/keytab/mokeyapp.keytab


### PR DESCRIPTION
Closes #98

I'm quite new to FreeIPA so this example might be heretical. But I've attempted to digest the [documentation](https://www.freeipa.org/page/V4/Managed_Read_permissions) for fulfilling this mokey requirement:

> Create a user account and role in FreeIPA with the "Modify users and Reset passwords" privilege. This user account will be used by the mokey application to reset users passwords. The "Modify Users" permission also needs to have the "ipauserauthtype" enabled.