### PR TITLE
Update mokey.toml.sample to comment out SMTP username and password

### DIFF
--- a/mokey.toml.sample
+++ b/mokey.toml.sample
@@ -117,8 +117,8 @@ smtp_port = 25
 smtp_tls = "off"
 
 # SMTP Authentication Credentials
-smtp_username = ""
-smtp_password = ""
+#smtp_username = ""
+#smtp_password = ""
 
 # Email signature to append to end of all emails
 signature = ""


### PR DESCRIPTION
By default, "smtp_tls" is disabled in mokey.toml, but attempting to send an email with this config results in an error from the SMTP server. By also commenting out "smtp_username" and "smtp_password", the unencrypted email can be sent successfully.