### PR TITLE
Implement admin verification requirement

### DIFF
--- a/mokey.toml.sample
+++ b/mokey.toml.sample
@@ -91,6 +91,10 @@ username_from_email = false
 # Two-Factor authentication.
 require_mfa = false
 
+# Require FreeIPA admin to activate the account. With this option enabled new
+# accounts are disabled by default until a FreeIPA admin activates them.
+require_admin_verify = false
+
 #------------------------------------------------------------------------------
 # Email
 #------------------------------------------------------------------------------

--- a/server/account.go
+++ b/server/account.go
@@ -215,7 +215,7 @@ func (r *Router) AccountVerify(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).SendString("Failed to verify account please contact administrator")
 	}
 
-	if user.Locked {
+	if user.Locked && !viper.GetBool("accounts.require_admin_verify") {
 		err := r.adminClient.UserEnable(claims.Username)
 		if err != nil {
 			log.WithFields(log.Fields{

--- a/server/account.go
+++ b/server/account.go
@@ -295,7 +295,7 @@ func (r *Router) AccountVerifyResend(c *fiber.Ctx) error {
 		return c.Render("account-verify-forgot-success.html", fiber.Map{})
 	}
 
-	if !user.Locked {
+	if !user.Locked && !viper.GetBool("accounts.require_admin_verify") {
 		log.WithFields(log.Fields{
 			"username": username,
 		}).Warn("Account verify resend attempt for active user")

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,7 @@ func SetDefaults() {
 	viper.SetDefault("accounts.otp_hash_algorithm", "sha1")
 	viper.SetDefault("accounts.username_from_email", false)
 	viper.SetDefault("accounts.require_mfa", false)
+	viper.SetDefault("accounts.require_admin_verify", false)
 	viper.SetDefault("email.token_max_age", 3600)
 	viper.SetDefault("email.smtp_host", "localhost")
 	viper.SetDefault("email.smtp_port", 25)

--- a/server/templates/signup-success.html
+++ b/server/templates/signup-success.html
@@ -7,7 +7,11 @@
             <div class="text-center">
             <p><span class="badge bg-success"><i class="fa-regular fa-circle-check"></i> Account created successfully</span></p>
             <p class="text-center">Your username is: <strong>{{ $.user.Username }}</strong></p>
+            {{ if not (ConfigValueBool "accounts.require_admin_verify") }}
             <p class="text-center">You must verify your email address to activate your account. Check your email for further instructions.</p>
+            {{ else }}
+            <p class="text-center">An administrator will need to activate your account before you can use it.</p>
+            {{ end }}
             </div>
         </div>
     </div>

--- a/server/templates/signup-success.html
+++ b/server/templates/signup-success.html
@@ -7,11 +7,15 @@
             <div class="text-center">
             <p><span class="badge bg-success"><i class="fa-regular fa-circle-check"></i> Account created successfully</span></p>
             <p class="text-center">Your username is: <strong>{{ $.user.Username }}</strong></p>
+            <p class="text-center">
             {{ if not (ConfigValueBool "accounts.require_admin_verify") }}
-            <p class="text-center">You must verify your email address to activate your account. Check your email for further instructions.</p>
+            You must verify your email address to activate your account.
             {{ else }}
-            <p class="text-center">An administrator will need to activate your account before you can use it.</p>
+            An administrator will need to activate your account before you can use it.
+            You must also verify your email address.
             {{ end }}
+            Check your email for further instructions.
+            </p>
             </div>
         </div>
     </div>

--- a/server/templates/verify-success.html
+++ b/server/templates/verify-success.html
@@ -5,7 +5,7 @@
     <div class="login-body p-4 p-md-5">
         <div class="login-body-wrapper mx-auto">
             <div class="text-center">
-            <p><span class="badge bg-success"><i class="fa-regular fa-circle-check"></i> Your account has been activated successfully. Thank you</span></p>
+            <p><span class="badge bg-success"><i class="fa-regular fa-circle-check"></i> Your account has been verified successfully. Thank you</span></p>
             <p><a href="/auth/login">Login</a></p>
             </div>
         </div>


### PR DESCRIPTION
Fix #121.

Marking this as draft as I haven't the chance to try it. The only thing I know for now is that it compiles.

The name of the parameter `accounts.require_admin_verify` is also up for discussion.

Contrary to previous version of Mokey, the email verification and admin verification are no longer mutually exclusive. The user can still verify its email, but if `accounts.require_admin_verify` is `true`, the account will not be enabled after the verification.