### PR TITLE
Add support for hiding invalid username error.

### DIFF
--- a/mokey.toml.sample
+++ b/mokey.toml.sample
@@ -95,6 +95,12 @@ require_mfa = false
 # accounts are disabled by default until a FreeIPA admin activates them.
 require_admin_verify = false
 
+# By default, login attempts for non-existent user accounts will be shown an
+# error message indicating that the username is not found in the system. If
+# your site is concerned about the potential for username enumeration attacks,
+# you could hide this error message by setting this to true.
+hide_invalid_username_error = false
+
 #------------------------------------------------------------------------------
 # Email
 #------------------------------------------------------------------------------

--- a/server/server.go
+++ b/server/server.go
@@ -40,6 +40,7 @@ type Server struct {
 func SetDefaults() {
 	viper.SetDefault("site.name", "Acme Widgets")
 	viper.SetDefault("site.ktuser", "mokeyapp")
+	viper.SetDefault("accounts.hide_invalid_username_error", false)
 	viper.SetDefault("accounts.default_homedir", "/home")
 	viper.SetDefault("accounts.default_shell", "/bin/bash")
 	viper.SetDefault("accounts.min_passwd_len", 8)


### PR DESCRIPTION
Fixes #92. Adds config option `hide_invalid_username_error` which defaults to false.