### PR TITLE
Upgrade goreleaser to version 2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # Mokey goreleaser configs
 # See here: https://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -18,11 +19,15 @@ builds:
       - osusergo
       - netgo
 archives:
-  - replacements:
-      linux: linux
-      amd64: x86_64
+  - id: release
     wrap_in_directory: true
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: >-
+      {{- .ProjectName }}-
+      {{- .Version }}-
+      {{- .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE
       - NOTICE
@@ -45,7 +50,12 @@ nfpms:
         scripts:
           postinstall: ./scripts/nfpm/postinstall.sh
       rpm:
-        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
+        file_name_template: >-
+          {{- .ProjectName }}-
+          {{- .Version }}-
+          {{- if eq .Arch "amd64" }}x86_64
+          {{- else if eq .Arch "arm64" }}aarch64
+          {{- else }}{{ .Arch }}{{ end }}
         scripts:
           postinstall: ./scripts/nfpm/postinstall.sh
     rpm:
@@ -66,7 +76,7 @@ nfpms:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}"
+  version_template: "{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}"
 changelog:
   sort: desc
   groups:


### PR DESCRIPTION
- Specify version number of goreleaser - 2.
- Replace deprecated `archive.replacements` by refactoring the `name_template`. [deprecation notice](https://goreleaser.com/deprecations/#archivesreplacements)
- Apply same template to nfpms file_name_templates. [deprecation notice](https://goreleaser.com/deprecations/#snapshotname_template)
