### PR TITLE
Replace user account doc by service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ $ sudo rpm -ivh mokey-VERSION-amd64.rpm
 
 ## Setup and configuration
 
-Create a user account and role in FreeIPA with the "Modify users and Reset
-passwords" privilege. This user account will be used by the mokey application
+Create a service account and role in FreeIPA with the "Modify users and Reset
+passwords" privilege. This service account will be used by the mokey application
 to reset users passwords. The "Modify Users" permission also needs to have the
 "ipauserauthtype" enabled. Run the following commands (requires ipa-admintools
 to be installed):
@@ -72,12 +72,14 @@ $ mkdir /etc/mokey/private
 $ kinit adminuser
 $ ipa role-add 'Mokey User Manager' --desc='Mokey User management'
 $ ipa role-add-privilege 'Mokey User Manager' --privilege='User Administrators'
-$ ipa user-add mokeyapp --first Mokey --last App
-$ ipa role-add-member 'Mokey User Manager' --users=mokeyapp
+$ ipa service-add mokey/$(hostname -f)
+$ ipa service-add-principal mokey/$(hostname -f) mokey/mokey
+$ ipa role-add-member 'Mokey User Manager' --service=mokey/mokey
 $ ipa permission-mod 'System: Modify Users' --includedattrs=ipauserauthtype
-$ ipa-getkeytab -s [your.ipa-master.server] -p mokeyapp -k /etc/mokey/private/mokeyapp.keytab
+$ ipa-getkeytab -s [your.ipa-master.server] -p mokey/mokey -k /etc/mokey/private/mokeyapp.keytab
 $ chmod 640 /etc/mokey/private/mokeyapp.keytab
 $ chgrp mokey /etc/mokey/private/mokeyapp.keytab
+$ kdestroy
 ```
 
 Edit mokey configuration file and set path to keytab file. The values for

--- a/mokey.toml.sample
+++ b/mokey.toml.sample
@@ -38,8 +38,8 @@ css = ""
 # css/javascript/images assets locally. Only used for advanced customization.
 # static_assets_dir = "/usr/share/mokey/assets"
 
-# User account for the mokey service
-ktuser = "mokeyapp"
+# Kerberos principal for the mokey service
+ktuser = "mokey/mokey"
 
 # Path to keytab file
 keytab = "/etc/mokey/private/mokeyapp.keytab"


### PR DESCRIPTION
Since mokey does not use the FreeIPA mokeyapp user, this PR suggests we instead define a mokey service in FreeIPA. The result is the same as we are able to retrieve a keytab with the required privileges, but without creating any user in LDAP.