### PR TITLE
Make request header read buffer size configurable (fixes 431 Request Header Fields Too Large)

### DIFF
--- a/mokey.toml.sample
+++ b/mokey.toml.sample
@@ -146,6 +146,10 @@ listen = "0.0.0.0:8866"
 # Times out the session after inactivity (in seconds)
 session_idle_timeout = 900
 
+# Max size in bytes of the request headers (increase if clients send large
+# cookies and requests fail with 431 Request Header Fields Too Large)
+# read_buffer_size = 16384
+
 # Path to ssl certificate
 # ssl_cert = ""
 

--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,7 @@ func SetDefaults() {
 	viper.SetDefault("server.idle_timeout", 120)
 	viper.SetDefault("server.rate_limit_expiration", 3600)
 	viper.SetDefault("server.rate_limit_max", 10)
+	viper.SetDefault("server.read_buffer_size", 16384)
 	viper.SetDefault("storage.driver", "memory")
 }
 
@@ -145,6 +146,7 @@ func newFiber() (*fiber.App, error) {
 		ReadTimeout:           time.Duration(viper.GetInt("server.read_timeout")) * time.Second,
 		WriteTimeout:          time.Duration(viper.GetInt("server.write_timeout")) * time.Second,
 		IdleTimeout:           time.Duration(viper.GetInt("server.idle_timeout")) * time.Second,
+		ReadBufferSize:        viper.GetInt("server.read_buffer_size"),
 		AppName:               "mokey",
 		DisableStartupMessage: true,
 		PassLocalsToViews:     true,


### PR DESCRIPTION
## Problem

Fiber's default `ReadBufferSize` is 4096 bytes, so mokey rejects any request whose headers exceed 4KB with **431 Request Header Fields Too Large**:

```
level=error msg="Request Header Fields Too Large" code=431 path=/ username="<nil>"
```

This happens easily when mokey runs on a (sub)domain shared with other applications that set large cookies, or behind auth proxies that add sizable headers. Reported in #122.

## Fix

- Add a `server.read_buffer_size` config option wired to `fiber.Config.ReadBufferSize`, defaulting to 16384.
- Document the option in `mokey.toml.sample`.

## Testing

Deployed in production behind Traefik where users' shared-domain cookies previously triggered 431s. Verified in the running container:

```
# before (v1.0.2 base): 5KB cookie
curl -H "Cookie: junk=<5KB>" http://localhost:8866/   -> 431
# after: 5KB and 12KB cookies
curl -H "Cookie: junk=<5KB>" http://localhost:8866/   -> 302
curl -H "Cookie: junk=<12KB>" http://localhost:8866/  -> 302
```

Fixes #122