### PR TITLE
Add unauthenticated /healthz endpoint

### DIFF
--- a/server/health.go
+++ b/server/health.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"github.com/gofiber/fiber/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+// Healthz is an unauthenticated health check endpoint. It verifies the
+// session storage backend and FreeIPA are reachable. Registered before the
+// CSRF middleware so probes don't create sessions.
+func (r *Router) Healthz(c *fiber.Ctx) error {
+	if _, err := r.storage.Get("healthz"); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error("healthz: session storage check failed")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"status":  "unavailable",
+			"storage": err.Error(),
+		})
+	}
+
+	if _, err := r.adminClient.Ping(); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error("healthz: FreeIPA ping failed")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"status":  "unavailable",
+			"freeipa": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"status": "ok",
+	})
+}

--- a/server/router.go
+++ b/server/router.go
@@ -93,6 +93,9 @@ func RemoteIP(c *fiber.Ctx) string {
 }
 
 func (r *Router) SetupRoutes(app *fiber.App) {
+	// Health check (no auth, no CSRF/session - must be registered first)
+	app.Get("/healthz", r.Healthz)
+
 	// CSRF tokens stored in sessions
 	app.Use(r.CSRF)
 


### PR DESCRIPTION
## Motivation

There is currently no way to health-check mokey without hitting authenticated pages: probing `/` (Kubernetes probes, blackbox_exporter, uptime monitors) redirects to login, logs `Login required and no authenticated session found` on every probe, and — because the CSRF middleware saves a session on every GET — creates a new session storage entry per probe.

## Changes

- New `GET /healthz` endpoint returning `200 {"status":"ok"}` when healthy, or `503` with the failing component when the session storage backend or FreeIPA is unreachable (uses `storage.Get` and the admin client's `Ping()`).
- Registered before the CSRF middleware, so probes don't create sessions and don't spam logs.

## Testing

Running in production as Kubernetes startup/readiness probe and blackbox_exporter target:

```
$ curl -s -w ' -> %{http_code}
' http://localhost:8866/healthz
{"status":"ok"} -> 200
```

Log spam from probes is gone, and no per-probe sessions accumulate in redis anymore.